### PR TITLE
Force remote user

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Installation
     wfloadExtension( 'RemoteauthNg' );
     // enable/disable auto user creation
     $wgRemoteAuthNgAutoCreateUser = false;
+    // force remote user
+    $wgRemoteAuthNgForceRemoteUser = true;
     ```
 
 3. Sit back and let the magic sink in. :sunglasses:

--- a/extension.json
+++ b/extension.json
@@ -18,7 +18,8 @@
         "RemoteAuthNG": "remoteauth-ng.php"
     },
     "config": {
-        "RemoteAuthNgAutoCreateUser": false
+        "RemoteAuthNgAutoCreateUser": false,
+        "RemoteAuthNgForceRemoteUser": true
     },
     "SessionProviders": {
         "RemoteAuthNG": {


### PR DESCRIPTION
Check if remote user is same as currently authenticated user.
If not, remote user will be logged in.

This can be disabled with the "RemoteAuthNgForceRemoteUser" config.